### PR TITLE
Readmeの記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Things you may want to cover:
 
 | Column             | Type   | Options     |
 | ------------------ | ------ | ----------- |
-| name               | string | null: false |
+| nickname           | string | null: false |
 | email              | string | null: false |
 | encrypted_password | string | null: false |
 | profile            | string | null: false |
-| class              | string | null: false |
+| affiliation        | string | null: false |
 | director           | string | null: false |
 
 
@@ -46,11 +46,11 @@ Things you may want to cover:
 
 | Column           | Type       | Options     |
 | ---------------- | ---------- | ----------- |
-| prototype_name   | string     | null: false |
+| name             | string     | null: false |
 | catch_copy       | string     | null: false |
 | concept          | string     | null: false |
 | image            | string     | null: false |
-| user_id          | references | null: false, foreign_key: true |
+| user             | references | null: false, foreign_key: true |
 
 ### Association
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,50 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# テーブル設計
+
+## users テーブル
+
+| Column             | Type   | Options     |
+| ------------------ | ------ | ----------- |
+| name               | string | null: false |
+| email              | string | null: false |
+| encrypted_password | string | null: false |
+| profile            | string | null: false |
+| class              | string | null: false |
+| director           | string | null: false |
+
+
+### Association
+
+- has_many :prototypes
+- has_many :comments
+
+## prototypes テーブル
+
+| Column           | Type       | Options     |
+| ---------------- | ---------- | ----------- |
+| prototype_name   | string     | null: false |
+| catch_copy       | string     | null: false |
+| concept          | string     | null: false |
+| image            | string     | null: false |
+| user_id          | references | null: false, foreign_key: true |
+
+### Association
+
+- belongs_to :user
+- has_many :comments
+
+## comments テーブル
+
+| Column       | Type       | Options                        |
+| ------------ | ---------- | ------------------------------ |
+| content      | string     |                                |
+| user         | references | null: false, foreign_key: true |
+| prototype    | references | null: false, foreign_key: true |
+
+### Association
+
+- belongs_to :prototype
+- belongs_to :user


### PR DESCRIPTION
**WHAT**
1.usersとprototypesのnameカラムの名前の変更
2.usersテーブルのカラム名「class」を「affiliation」に変更
3.オプションにforeign_key: trueがついているカラム名の変更

**WHY**
1.prototype_nameだと見にくくなるのでわかりやすいようにするため
2.Railsの予約語にClassがあったから
3.https://qiita.com/ryouzi/items/2682e7e8a86fd2b1ae47　を参考にしてカラム名の「_id」の部分がいらないと思ったため