### PR TITLE
プロトタイプ情報削除機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :basic_auth
+  before_action :authenticate_user!, except: [:index, :show]
 
   private
   def configure_permitted_parameters

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -20,6 +20,11 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
+    def destroy
+      prototype = Prototype.find(params[:id])
+      prototype.destroy
+      redirect_to root_path
+    end
   end
 
   def edit

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -20,11 +20,9 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
-    def destroy
       prototype = Prototype.find(params[:id])
       prototype.destroy
       redirect_to root_path
-    end
   end
 
   def edit

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -9,7 +9,7 @@
       <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+          <%= link_to '削除する', "/prototypes/#{@prototype.id}", method: :delete, class: :prototype__btn %>
         </div>
       <% end %>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'prototypes#index'
-  resources :prototypes, only: [:index, :new, :create, :show]
+  resources :prototypes, only: [:index, :new, :create, :show, :destroy]
   resources :users, only: :show
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
# What
プロトタイプ削除機能の実装

# Why
ログインしたユーザーのみが自分の投稿したプロトタイプを削除できるようにする
ログアウト時に削除しようとするとログインページにリダイレクトする（検証は不要）

# Gyazoリンク
https://gyazo.com/d918f6aac1c85e00b258846e64e1266c